### PR TITLE
Allow #:serial-number #f in hid-open

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 hidapi
 ======
-Racket interface to [hidapi](https://github.com/signal11/hidapi) library.
+Racket interface to [hidapi](https://github.com/libusb/hidapi) library.

--- a/main.rkt
+++ b/main.rkt
@@ -62,7 +62,7 @@
   [hid-enumerate (->* ()
                       (#:vendor-id integer? #:product-id integer?)
                       (listof hid-device-info?))]
-  [hid-open (-> #:vendor-id integer? #:product-id integer? #:serial-number string?
+  [hid-open (-> #:vendor-id integer? #:product-id integer? #:serial-number (or/c string? #f)
                 (or/c hid-device? #f))]
   [hid-open-path (-> path? (or/c hid-device? #f))]
   [hid-set-nonblocking (-> hid-device? boolean? void?)]

--- a/scribblings/hidapi.scrbl
+++ b/scribblings/hidapi.scrbl
@@ -8,7 +8,7 @@
 
 @defmodule[hidapi]
 
-This package provides bindings to @link["https://github.com/signal11/hidapi"]{hidapi} library.
+This package provides bindings to @link["https://github.com/libusb/hidapi"]{hidapi} library.
 The library name is searched in the order:@linebreak{}
 @filepath{libhidapi} @filepath{libhidapi-libusb} @filepath{libhidapi-hidraw}
 


### PR DESCRIPTION
Partial fix for #2: add (or/c ... #f) to contract for hid-open.

I'm not familiar enough with define-ffi-definer to make the keyword parameter optional, but that would also be nice to have.
